### PR TITLE
CLI version added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 *.out
 *.app
 meteorite
+meteorite-cli

--- a/README.md
+++ b/README.md
@@ -6,70 +6,101 @@ This is a fork of an abandoned (I believe) project from SourceForge.
 See [Documentation from original website](#documentation-from-original-website)
 below for full details.
 
-* Version 0.20 Copyright (C) 2016 Andrew Barnert
+* Version 0.20+ Copyright (C) 2016 Andrew Barnert
 * Version 0.12 Copyright (C) 2009 Erdem U. Altinyurt
 * Licensed under GPL version 2.0 or later. See docs/GPL.txt for details.
 
 #Build
 
-Meteorite requires [wxWidgets][wx]. Tested with version 3.0 and 3.1,
-installed via `brew install wxmac` and Windows installer. There may
-be other prereqs; I honestly don't know yet.
+Meteorite requires [wxWidgets][wx], probably at least 2.8 or 3.0.
+Tested with version 3.0 and 3.1, installed via `brew install wxmac` 
+and Windows installer. There may be other prereqs; I honestly don't 
+know yet. Note that wxWidgets is currently required to build even
+just the CLI version.
 
   [wx]: https://www.wxwidgets.org/
 
-* `make` should work to build an executable on any platform, which
-will run from the source tree.
+* `make` builds two executables, `meteorite` and
+  `meteorite-cli`, which will run from the source tree.
+* `make cli` builds only `meteorite-cli`.
 * `[sudo] make install` may work on some platforms, but I don't
-know how far I'd trust it. (It does handle the usual `$DESTDIR`, 
-`$PREFIX`, etc. customizations.) I definitely wouldn't use it on Mac.
+  know how far I'd trust it. (It does handle the usual `$DESTDIR`, 
+  `$PREFIX`, etc. customizations.) I definitely wouldn't use it on Mac.
 * `make mac` will build a `.app` bundle, which can then be copied
-into your applications directory. (However, at present, you'll
-probably want to run it from a terminal anyway.)
+  into your applications directory. (However, at present, you'll
+  probably want to run it from a terminal anyway.)
 * `make win` will build... hopefully something useful; not sure what.
 * `contrib/meteorite.spec` can presumably be used for building an
 RPM package.
 
 #Use (including known issues)
 
-Currently, there are no command-line argumetns.
+Currently, the build produces two separate executables.
 
-On the Mac, this means you will probably want to run the app
-from the terminal. If you're running out of the source tree,
-that's of course just `./meteorite`. If you've build a `.app`
-bundle, it'll be something like
-`/Applications/meteorite.app/Contents/MacOS/meteorite`.
+##CLI
 
-When the app is launched, it just presents a small window. Drag
-a `.mkv` movie from Finder/Explorer/Nautilus/etc. to that window,
-and it will begin creating a repaired version, in the same
-directory, with `Meteorite.` prefixed to the name. So, for
-example, if you fix `~/Movies/spam.mkv`, you will get
+The CLI can be run directly from the build directory, or from the
+install directory.
+
+    meteorite-cli FILENAME [FILENAME]*
+
+For each `FILENAME`, this creates a repaired file, prefixed with
+`Meteorite.`, in the same directory. There are no flags or options.
+So, for example, if you fix `~/Movies/spam.mkv`, you will get
 `~/Movies/Meteorite.spam.mkv`.
 
-There's no useful GUI feedback, but there is a lot of debug 
-information dumped to the terminal. Usually, the last piece
-of information will be a dump of the final structure, which
-should end with a line similar to this:
+Currently, there's a whole lot of debug information, dumped to both
+stderr and stdout. However, at the end of each file, you should get a
+banner like this:
+
+    ************************************************************
+    SUCCESS: src -> /Users/andi/test.mkv -> /Users/andi/Meteorite.test.mkv
+    ************************************************************
+
+There may be a bug that causes it to hang at completion, but I believe
+this only affects the GUI build.
+
+You should be able to safely interrupt a repair with `^C` (although
+this will leave a useless incomplete destination file).
+
+##GUI
+
+The GUI can be run directly from the build directory as `meteorite`,
+or (on Mac) by opening the `meteorite.app` bundle. There are no
+command-line arguments.
+
+Launching the app displays a drop target. Drag one or more files to
+the drop target, and the app should behave the same as if you'd passed
+the same files to the CLI.
+
+There's no GUI feedback. This means you will probably want to run the
+app from the terminal. On Mac, if you've built an an app bundle, this
+should be something like `./meteorite.app/Contents/MacOS/meteorite` or
+(if you've copied that bundle to the Applications directory)
+`/Applications/meteorite.app/Contents/MacOS/meteorite`.
+
+There's also no CLI feedback except for the debug
+information. Usually, the last piece of information will be a dump of
+the final structure, which should end with a line similar to this:
 
     |-Void: 00000000000000000000: size 5035
 
-After the output has stopped, quit the app, to make sure the
-file is flushed and closed, and now it should play. (If you
-attempt to quit before it's done, it will probably segfault
-and leave a partial output file behind.)
+If you're not sure whether the repair has completed, quit the app, to
+make sure the file is flushed and closed, and now it should play.
 
-Note that on the Mac version, the menu bar is broken. This
-means you can't quit from the `Meteorite` menu, or with the 
-usual Cmd-Q shortcut. (Although, oddly, there is a context
-menu that works.) Just close the window to quit.
+You can quit the app before it's done, but it will probably segfault.
 
-Sometimes, at completion, the app hangs. Killing it (`^C` from
-the terminal, or `kill` (no `-9` needed), or your favorite GUI
-tool seems to be safe—at least the file still ends up flushed.
-I don't know whether this is related to a warning that
-gets logged by `CoreAnimation` on the Mac about ending a thread
-with an open transaction, but it certainly looks suspicious.
+Note that on the Mac version, the menu bar is broken. This means you
+can't quit from the `Meteorite` menu, or with the usual Cmd-Q
+shortcut. (Although, oddly, there is a context menu that works.) Just
+close the window to quit.
+
+Sometimes, at completion, the app hangs. Killing it (`^C` from the
+terminal, or `kill` (no `-9` needed), or your favorite GUI tool is
+safe; any output files have been flushed. I don't know whether this is
+related to a warning that gets logged by `CoreAnimation` on the Mac
+about ending a thread with an open transaction, but it certainly looks
+suspicious.
 
 #Roadmap
 
@@ -77,17 +108,25 @@ with an open transaction, but it certainly looks suspicious.
  * Fork original Sourceforge repo.
  * Get the code compiling again.
  * Fix the startup crash.
-* Version 0.21
- * Hopefully fix any other critical bugs.
- * Fix linux build (missing `.desktop` file).
-* Version 0.30
+* Version 0.30 (done, 2016-07-11)
  * Create a version that works as a command-line tool.
+* Version 0.31
+ * `getopt_long` to control logging levels, specify output dir, etc.
+ * Clean up logging.
+ * Clean up CLI output.
  * Fix hang on completion bug.
+* Version 0.32
+ * Add interactive CLI feedback (progress spinner).
+* Version 0.40
+ * Add interactive GUI feedback.
+ * Add basic options in GUI.
+ * Make menu bar work in GUI.
+ * Make cancel not crash in GUI.
 * Future
  * Make wx optional for building.
- * Add some feedback to the GUI.
- * Add some low-verbosity modes for the CLI.
- * Add options to both GUI and CLI.
+ * Ideally merge two executables into one when built with wx.
+ * Make GUI also handle command-line input.
+ * Some way to specify validate/dry-run.
  * Food in pill form.
 
 #Original version information

--- a/contrib/meteorite.spec
+++ b/contrib/meteorite.spec
@@ -12,7 +12,7 @@
 
 Name:			meteorite
 Summary:		A program to repair broken MKV file streams
-Version:		0.20
+Version:		0.30
 Release:		1
 License:		GPL
 Group:			Productivity/Multimedia/Video/Editors and Convertors
@@ -52,6 +52,7 @@ dos2unix     docs/*
 %__install -dm 755 %{buildroot}%{_datadir}/applications
 %__rm -f %{buildroot}%{_datadir}/applications/%{name}.desktop
 %__install -D -s -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+%__install -D -s -m 755 %{name}-cli %{buildroot}%{_bindir}/%{name}-cli
 %__install -D -m 644 resources/%{name}.ico %{buildroot}%{_datadir}/pixmaps/%{name}.ico
 %__cat > %{name}.desktop << EOF
 [Desktop Entry]
@@ -76,6 +77,7 @@ EOF
 %defattr(-,root,root)
 %doc docs/*
 %{_bindir}/%{name}
+%{_bindir}/%{name}-cli
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/pixmaps/%{name}.ico
 
@@ -85,3 +87,6 @@ EOF
 
 * Mon Jul 11 2016 Andrew Barnert 0.20
 - Revive dead project, get it building again.
+
+* Mon Jul 11 2016 Andrew Barnert 0.30
+- Create CLI version.

--- a/makefile
+++ b/makefile
@@ -56,11 +56,13 @@ $(EXECUTABLE_WIN): $(OBJECTS) $(RESOURCE_OBJ)
 
 install:
 	install -D -m 755 $(EXECUTABLE) $(BINDIR)/$(EXECUTABLE)
+	install -D -m 755 $(EXECUTABLE_CLI) $(BINDIR)/$(EXECUTABLE_CLI)
 	install -D -m 644 resources/$(EXECUTABLE).png $(DATADIR)/pixmaps/$(EXECUTABLE).png
 	install -D -m 644 resources/$(EXECUTABLE).desktop $(DATADIR)/applications/$(EXECUTABLE).desktop
 
 uninstall:
 	rm $(BINDIR)/$(EXECUTABLE)
+	rm $(BINDIR)/$(EXECUTABLE_CLI)
 	rm $(DATADIR)/pixmaps/$(EXECUTABLE).png
 	rm $(DATADIR)/applications/$(EXECUTABLE).desktop
 	rm $(LOCALEDIR)/*/LC_MESSAGES/$(EXECUTABLE).mo
@@ -73,6 +75,7 @@ clean:
 	rm -f resources/resource.o
 	rm -f locale/*/$(EXECUTABLE).mo
 	rm -f $(EXECUTABLE)
+	rm -f $(EXECUTABLE_CLI)
 	rm -f $(EXECUTABLE_WIN)
 	rm -rf $(EXECUTABLE).app
 
@@ -98,7 +101,7 @@ mac: all
  	\t<string>$(EXECUTABLE)</string>\n\
 \
 	\t<key>CFBundleGetInfoString</key>\n\
-	\t<string>$(EXECUTABLE) v0.20</string>\n\
+	\t<string>$(EXECUTABLE) v0.30</string>\n\
 \
 	\t<key>CFBundleIconFile</key>\n\
 	\t<string>$(EXECUTABLE).icns</string>\n\
@@ -107,7 +110,7 @@ mac: all
  	\t<string>net.sourceforge.divfixpp</string>\n\
 \
   	\t<key>CFBundleShortVersionString</key>\n\
- 	\t<string>v0.20</string>\n\
+ 	\t<string>v0.30</string>\n\
 \
   	\t<key>CFBundleInfoDictionaryVersion</key>\n\
  	\t<string>6.0</string>\n\

--- a/makefile
+++ b/makefile
@@ -7,16 +7,24 @@ RC = `$(WXCONFIG) --rescomp`
 RCFLAGS = `$(WXCONFIG) --cxxflags`
 MSGFMT = msgfmt
 
-SOURCES= src/MeteoriteApp.cpp\
+SOURCES_GUI= src/MeteoriteApp.cpp\
 			src/MeteoriteGUI.cpp\
 			src/MeteoriteMain.cpp\
 			src/meteoritewx.cpp\
 			src/meteorite.cpp
-OBJECTS=$(SOURCES:.cpp=.o)
-DEPENDS=$(OBJECTS:.o=.d)
+SOURCES_CLI= src/meteorite.cpp \
+			src/meteoritecli.cpp
+OBJECTS_GUI=$(SOURCES_GUI:.cpp=.o)
+DEPENDS_GUI=$(OBJECTS_GUI:.o=.d)
+OBJECTS_CLI=$(SOURCES_CLI:.cpp=.o)
+DEPENDS_CLI=$(OBJECTS_CLI:.o=.d)
+SOURCES=$(SOURCES_GUI) $(SOURCES_CLI)
+OBJECTS=$(OBJECTS_GUI) $(OBJECTS_CLI)
+DEPENDS=$(DEPENDS_GUI) $(DEPENDS_CLI)
 RESOURCES= resources/resource.rc
 RESOURCE_OBJ=$(RESOURCES:.rc=.o)
 EXECUTABLE=meteorite
+EXECUTABLE_CLI=meteorite-cli
 EXECUTABLE_WIN=Meteorite.exe
 
 DESTDIR		=
@@ -25,10 +33,15 @@ BINDIR	    = $(PREFIX)/bin
 DATADIR	    = $(PREFIX)/share
 LOCALEDIR   = $(DATADIR)/locale
 
-all: $(SOURCES) $(EXECUTABLE)
+all: $(SOURCES) $(EXECUTABLE) $(EXECUTABLE_CLI)
 
-$(EXECUTABLE): $(OBJECTS)
-	$(CPP) $(OBJECTS) $(LDFLAGS) -o $@
+cli: $(SOURCES_CLI) $(EXECUTABLE_CLI)
+
+$(EXECUTABLE): $(OBJECTS_GUI)
+	$(CPP) $(OBJECTS_GUI) $(LDFLAGS) -o $@
+
+$(EXECUTABLE_CLI): $(OBJECTS_CLI)
+	$(CPP) $(OBJECTS_CLI) $(LDFLAGS) -o $@
 
 win: $(SOURCES) $(RESOURCES) $(EXECUTABLE_WIN)
 

--- a/makefile
+++ b/makefile
@@ -10,6 +10,7 @@ MSGFMT = msgfmt
 SOURCES= src/MeteoriteApp.cpp\
 			src/MeteoriteGUI.cpp\
 			src/MeteoriteMain.cpp\
+			src/meteoritewx.cpp\
 			src/meteorite.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 DEPENDS=$(OBJECTS:.o=.d)

--- a/src/MeteoriteMain.cpp
+++ b/src/MeteoriteMain.cpp
@@ -23,7 +23,7 @@ BEGIN_EVENT_TABLE(MeteoriteDialog,wxDialog )
 END_EVENT_TABLE()
 
 MeteoriteDialog::MeteoriteDialog(wxDialog *dlg)
-    : MeteoriteGUI(dlg), Meteorite( WxGauge )
+    : MeteoriteGUI(dlg), MeteoriteWx( WxGauge )
 {
 	SetDropTarget( new MeteoriteDropTarget(this)  );
 	wxMemoryInputStream png_stream( meteorite_logo, sizeof(meteorite_logo));

--- a/src/MeteoriteMain.h
+++ b/src/MeteoriteMain.h
@@ -12,7 +12,7 @@
 
 #include "MeteoriteApp.h"
 #include "MeteoriteGUI.h"
-#include "meteorite.h"
+#include "meteoritewx.h"
 #include <wx/dnd.h>
 #include <wx/file.h>
 #include <wx/filename.h>
@@ -24,7 +24,7 @@
 #include "../resources/meteorite-logo.hpp"
 #include "../resources/meteorite.xpm"
 
-class MeteoriteDialog: public MeteoriteGUI, Meteorite, wxThreadHelper
+class MeteoriteDialog: public MeteoriteGUI, MeteoriteWx, wxThreadHelper
 {
     public:
         MeteoriteDialog(wxDialog *dlg);

--- a/src/meteorite.cpp
+++ b/src/meteorite.cpp
@@ -748,41 +748,12 @@ void Block::Print( ){
 			cout << "\tFrames: " << Frames;
 		}
 
-Meteorite::Meteorite( wxGauge *WxGauge_ ){
+Meteorite::Meteorite(){
 	Init();
-	WxGauge = WxGauge_;
 	}
-void Meteorite::SetGauge( wxGauge *WxGauge_){
-	WxGauge = WxGauge_;
-}
 
 void Meteorite::Init(void){
 	filesize=0;
-	}
-bool Meteorite::update_gauge( int percent ){	//return indicate program live, false on kill req
-	if(WxGauge){
-		if( WxGauge->GetValue() != percent ){		//Checks value is changed or not
-			wxMutexGuiEnter();
-			WxGauge->SetValue( percent );
-			wxYield();
-			wxMutexGuiLeave();
-			}
-		}
-	else{
-//		wxString value;
-//		wxGetEnv( wxT("COLUMNS"), &value);
-//		std::cout << "\r" << value.ToAscii() << " "  << target_file.ToAscii() << "\t\%" << percent;
-		}
-
-	if( !wxThread::This()->IsMain() )							//Checks if functions is running on thread
-		if( wxThread::This()->TestDestroy() ){		//Checks if thread has termination request
-//			close_files(true);				//Releases files
-//			infile.close();
-//			outfile.close();
-//			MemoLogWriter(_("Operation stoped by user.\n"));
-			return false;
-			}
-	return true;
 	}
 
 uint32_t Meteorite::IDof( string name ){
@@ -1940,7 +1911,7 @@ bool Meteorite::Repair( string source, string target ){
 			TreeParserPrint( root );
 			string a = "ABCDEFGH";
 			cout << "Source: " << source << endl;
-			#if __WXMSW__
+			#ifdef __WIN32__
 			int found = source.find_last_of('\\');
 			#else
 			int found = source.find_last_of('/');
@@ -2039,7 +2010,7 @@ bool Meteorite::ClustersCopier( subElement* root, uint64_t SegmentStart, uint64_
 	subElement* MetaSeek_ptr= dynamic_cast< subElement* >(Get( root, IDof("SeekHead") ));
 	if ( MetaSeek_ptr == NULL ){
 		//Error here, what did I miss?
-		wxMessageBox( wxT("Error : There is no SeekHead located at file.\nProbably your file heavly damaged or using new versions of Matroska,\nthat doesn't supported by this program, yet.."), wxT("Different Matroska Format Detected"), wxOK|wxCENTER );
+		alert("Error : There is no SeekHead located at file.\nProbably your file heavly damaged or using new versions of Matroska,\nthat doesn't supported by this program, yet..", "Different Matroska Format Detected");
 		return false;
 		}
 	for( unsigned i = 0 ; i < MetaSeek_ptr->data.size() ; i++){

--- a/src/meteorite.cpp
+++ b/src/meteorite.cpp
@@ -1,5 +1,6 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
+*   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
 *   This program is free software; you can redistribute it and/or       *
@@ -17,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include "meteorite.h"

--- a/src/meteorite.h
+++ b/src/meteorite.h
@@ -185,18 +185,18 @@ struct Block{		//Block structure for read/store block informations. Structure do
 #define bfr_size 64*1024*1024	//64MB buffer
 class Meteorite{	//The main class of the poject_Meteorite
 	public:
-		Meteorite( wxGauge *WxGauge=NULL );
+		Meteorite();
 	protected:
-		wxGauge    *WxGauge;
+		//return indicate program live, false on kill req
+		virtual bool update_gauge( int percent ) = 0;
+		virtual void alert( string msg, string title ) = 0;
 
 		IDDB DB;
 		char four_cc[5];
-		bool update_gauge( int percent );
 		uint64_t filesize;
 
 	public:
 		void Init(void);
-		void SetGauge( wxGauge* );
 		uint32_t IDof( string name );
 		bool is_IDof( char* bfr, string name);
 		ID_Element* FindElementID( HeadIDs hid, char *bfr );

--- a/src/meteorite.h
+++ b/src/meteorite.h
@@ -1,5 +1,6 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
+*   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
 *   This program is free software; you can redistribute it and/or       *
@@ -17,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include <iostream>
@@ -43,7 +43,7 @@
 #ifndef _meteorite_h_
 #define _meteorite_h_
 
-#define METEORITE_VERSION "0.20"
+#define METEORITE_VERSION "0.30"
 
 using namespace std;
 

--- a/src/meteoritecli.cpp
+++ b/src/meteoritecli.cpp
@@ -1,5 +1,5 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
 *   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
@@ -18,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include "meteoritecli.h"
@@ -40,7 +39,7 @@ static string prefixify(string path, string prefix) {
 int main(int argc, char *argv[]) {
   // TODO: Real getopt_long-style interface
   if (argc == 1) {
-    cerr << "Usage: " << argv[0] << " FILENAME\n";
+    cerr << "Usage: " << argv[0] << " FILENAME [FILENAME]*\n";
     return 2;
   }
   MeteoriteCli cli;
@@ -51,12 +50,12 @@ int main(int argc, char *argv[]) {
     cerr << argv[arg] << ": Starting\n";
     if (cli.Repair(src, dst)) {
       cerr << "************************************************************\n"
-	   << "SUCCESS: src" << " -> " << dst << "\n"
+	   << "SUCCESS: " << src << " -> " << dst << "\n"
 	   << "************************************************************\n"
 	   << "\n";
     } else {
       cerr << "************************************************************\n"
-	   << "FAILURE: src" << " -> " << dst << "\n"
+	   << "FAILURE: " << src << " -> " << dst << "\n"
 	   << "************************************************************\n"
 	   << "\n";
     }

--- a/src/meteoritecli.cpp
+++ b/src/meteoritecli.cpp
@@ -1,0 +1,84 @@
+/***********************************(GPL)********************************
+*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Copyright (C) 2016  Andrew Barnert                                  *
+*   Copyright (C) 2009  Erdem U. Altinyurt                              *
+*                                                                       *
+*   This program is free software; you can redistribute it and/or       *
+*   modify it under the terms of the GNU General Public License         *
+*   as published by the Free Software Foundation; either version 2      *
+*   of the License.                                                     *
+*                                                                       *
+*   This program is distributed in the hope that it will be useful,     *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *
+*   GNU General Public License for more details.                        *
+*                                                                       *
+*   You should have received a copy of the GNU General Public License   *
+*   along with this program;                                            *
+*   if not, write to the Free Software Foundation, Inc.,                *
+*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
+*                                                                       *
+*               home  : meteorite.sourceforge.net                       *
+*               email : spamjunkeater at gmail.com                      *
+*************************************************************************/
+
+#include "meteoritecli.h"
+using namespace std;
+
+#ifdef __MSWIN__
+static const char *pathseps = "\\/";
+#else
+static const char *pathseps = "/";
+#endif
+
+static string prefixify(string path, string prefix) {
+  size_t slash = path.find_last_of(pathseps);
+  if (slash == string::npos) return prefix + path;
+  return path.substr(0, slash+1) + prefix + path.substr(slash+1);
+}
+
+int main(int argc, char *argv[]) {
+  // TODO: Real getopt_long-style interface
+  if (argc == 1) {
+    cerr << "Usage: " << argv[0] << " FILENAME\n";
+    return 2;
+  }
+  MeteoriteCli cli;
+  for (int arg = 1; arg != argc; ++arg) {
+    string src = argv[arg];
+    string dst = prefixify(src, "Meteorite.");
+    cerr << src << " -> " << dst << "\n";
+    cerr << argv[arg] << ": Starting\n";
+    if (cli.Repair(src, dst)) {
+      cerr << "************************************************************\n"
+	   << "SUCCESS: src" << " -> " << dst << "\n"
+	   << "************************************************************\n"
+	   << "\n";
+    } else {
+      cerr << "************************************************************\n"
+	   << "FAILURE: src" << " -> " << dst << "\n"
+	   << "************************************************************\n"
+	   << "\n";
+    }
+  }
+}
+
+MeteoriteCli::MeteoriteCli(bool interactive /*=false*/)
+  : interactive_(interactive) {}
+
+bool MeteoriteCli::update_gauge(int percent) {
+  if (interactive_) {
+    // TODO: Fancy progress spinner
+    cout << percent << "% done\n";
+  } else {
+    cerr << percent << "% done\n";
+  }
+  return true;
+}
+
+void MeteoriteCli::alert(string msg, string title) {
+  cout << "************************************************************\n"
+       << title << "\n\n"
+       << msg << "\n"
+       << "************************************************************\n";
+}

--- a/src/meteoritecli.h
+++ b/src/meteoritecli.h
@@ -1,0 +1,35 @@
+/***********************************(GPL)********************************
+*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Copyright (C) 2016  Andrew Barnert                                  *
+*   Copyright (C) 2009  Erdem U. Altinyurt                              *
+*                                                                       *
+*   This program is free software; you can redistribute it and/or       *
+*   modify it under the terms of the GNU General Public License         *
+*   as published by the Free Software Foundation; either version 2      *
+*   of the License.                                                     *
+*                                                                       *
+*   This program is distributed in the hope that it will be useful,     *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *
+*   GNU General Public License for more details.                        *
+*                                                                       *
+*   You should have received a copy of the GNU General Public License   *
+*   along with this program;                                            *
+*   if not, write to the Free Software Foundation, Inc.,                *
+*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
+*                                                                       *
+*               home  : meteorite.sourceforge.net                       *
+*               email : spamjunkeater at gmail.com                      *
+*************************************************************************/
+
+#include "meteorite.h"
+
+class MeteoriteCli : public Meteorite {
+public:
+  MeteoriteCli(bool interactive=false);
+private:
+  bool interactive_;
+protected:
+  virtual bool update_gauge(int percent);
+  virtual void alert(string msg, string title);  
+};

--- a/src/meteoritecli.h
+++ b/src/meteoritecli.h
@@ -1,5 +1,5 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
 *   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
@@ -18,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include "meteorite.h"

--- a/src/meteoritewx.cpp
+++ b/src/meteoritewx.cpp
@@ -1,5 +1,5 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
 *   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
@@ -18,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include "meteoritewx.h"

--- a/src/meteoritewx.cpp
+++ b/src/meteoritewx.cpp
@@ -1,0 +1,68 @@
+/***********************************(GPL)********************************
+*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Copyright (C) 2016  Andrew Barnert                                  *
+*   Copyright (C) 2009  Erdem U. Altinyurt                              *
+*                                                                       *
+*   This program is free software; you can redistribute it and/or       *
+*   modify it under the terms of the GNU General Public License         *
+*   as published by the Free Software Foundation; either version 2      *
+*   of the License.                                                     *
+*                                                                       *
+*   This program is distributed in the hope that it will be useful,     *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *
+*   GNU General Public License for more details.                        *
+*                                                                       *
+*   You should have received a copy of the GNU General Public License   *
+*   along with this program;                                            *
+*   if not, write to the Free Software Foundation, Inc.,                *
+*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
+*                                                                       *
+*               home  : meteorite.sourceforge.net                       *
+*               email : spamjunkeater at gmail.com                      *
+*************************************************************************/
+
+#include "meteoritewx.h"
+using namespace std;
+
+
+MeteoriteWx::MeteoriteWx( wxGauge *WxGauge_ ){
+	WxGauge = WxGauge_;
+	}
+void MeteoriteWx::SetGauge( wxGauge *WxGauge_){
+	WxGauge = WxGauge_;
+}
+
+bool MeteoriteWx::update_gauge( int percent ){	//return indicate program live, false on kill req
+	if(WxGauge){
+		if( WxGauge->GetValue() != percent ){		//Checks value is changed or not
+			wxMutexGuiEnter();
+			WxGauge->SetValue( percent );
+			wxYield();
+			wxMutexGuiLeave();
+			}
+		}
+	else{
+//		wxString value;
+//		wxGetEnv( wxT("COLUMNS"), &value);
+//		std::cout << "\r" << value.ToAscii() << " "  << target_file.ToAscii() << "\t\%" << percent;
+		}
+
+	if( !wxThread::This()->IsMain() )							//Checks if functions is running on thread
+		if( wxThread::This()->TestDestroy() ){		//Checks if thread has termination request
+//			close_files(true);				//Releases files
+//			infile.close();
+//			outfile.close();
+//			MemoLogWriter(_("Operation stoped by user.\n"));
+			return false;
+			}
+	return true;
+	}
+
+// NOTE: I believe this requires wx 2.8+ or 3.0+ (and will do a
+// wasteful checking conversion from ASCII to UTF-16 on Windows,
+// or to UTF-32 and back to UTF-8 on Mac and Linux, or something
+// like that. But it works.
+void MeteoriteWx::alert(string msg, string title) {
+  wxMessageBox(msg, title, wxOK|wxCENTER);
+}

--- a/src/meteoritewx.h
+++ b/src/meteoritewx.h
@@ -1,5 +1,5 @@
 /***********************************(GPL)********************************
-*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Meteorite is an MKV/Matroska Video Repair Engine.                   *
 *   Copyright (C) 2016  Andrew Barnert                                  *
 *   Copyright (C) 2009  Erdem U. Altinyurt                              *
 *                                                                       *
@@ -18,8 +18,7 @@
 *   if not, write to the Free Software Foundation, Inc.,                *
 *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
 *                                                                       *
-*               home  : meteorite.sourceforge.net                       *
-*               email : spamjunkeater at gmail.com                      *
+*              home : https://github.com/abarnert/meteorite             *
 *************************************************************************/
 
 #include "meteorite.h"

--- a/src/meteoritewx.h
+++ b/src/meteoritewx.h
@@ -1,0 +1,41 @@
+/***********************************(GPL)********************************
+*   Meteorite is MKV/Matroska Video Repair Engine.                      *
+*   Copyright (C) 2016  Andrew Barnert                                  *
+*   Copyright (C) 2009  Erdem U. Altinyurt                              *
+*                                                                       *
+*   This program is free software; you can redistribute it and/or       *
+*   modify it under the terms of the GNU General Public License         *
+*   as published by the Free Software Foundation; either version 2      *
+*   of the License.                                                     *
+*                                                                       *
+*   This program is distributed in the hope that it will be useful,     *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *
+*   GNU General Public License for more details.                        *
+*                                                                       *
+*   You should have received a copy of the GNU General Public License   *
+*   along with this program;                                            *
+*   if not, write to the Free Software Foundation, Inc.,                *
+*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA        *
+*                                                                       *
+*               home  : meteorite.sourceforge.net                       *
+*               email : spamjunkeater at gmail.com                      *
+*************************************************************************/
+
+#include "meteorite.h"
+
+#include <wx/thread.h>
+#include <wx/gauge.h>
+#include <wx/msgdlg.h>
+
+class MeteoriteWx : public Meteorite {
+public:
+  MeteoriteWx(wxGauge *WxGauge=NULL);
+protected:
+  wxGauge *WxGauge;
+public:
+  void SetGauge(wxGauge *);
+protected:
+  virtual bool update_gauge(int percent);
+  virtual void alert(string msg, string title);  
+};


### PR DESCRIPTION
This works, but it's less than ideal:
- You still need a wx installation to build.
- You get two separate executables, `meteorite` and `meteorite-cli`.
- The output is still chock full of debug logging.
- May not work on Windows.
