### PR TITLE
remove Wx dependency & build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,24 @@ below for full details.
 
 #Build
 
-Meteorite requires [wxWidgets][wx], probably at least 2.8 or 3.0.
+The Meteorite command line interface (CLI) version only requires a C++ compiler to 
+build (g++ 4.6 works well - also on Windows).
+The Meteorite GUI requires [wxWidgets][wx], probably at least 2.8 or 3.0.
 Tested with version 3.0 and 3.1, installed via `brew install wxmac` 
 and Windows installer. There may be other prereqs; I honestly don't 
-know yet. Note that wxWidgets is currently required to build even
-just the CLI version.
+know yet.
 
   [wx]: https://www.wxwidgets.org/
 
+* `make cli` builds only `meteorite-cli[.exe]`.
 * `make` builds two executables, `meteorite` and
   `meteorite-cli`, which will run from the source tree.
-* `make cli` builds only `meteorite-cli`.
 * `[sudo] make install` may work on some platforms, but I don't
   know how far I'd trust it. (It does handle the usual `$DESTDIR`, 
   `$PREFIX`, etc. customizations.) I definitely wouldn't use it on Mac.
 * `make mac` will build a `.app` bundle, which can then be copied
   into your applications directory. (However, at present, you'll
   probably want to run it from a terminal anyway.)
-* `make win` will build... hopefully something useful; not sure what.
 * `contrib/meteorite.spec` can presumably be used for building an
 RPM package.
 
@@ -50,7 +50,12 @@ So, for example, if you fix `~/Movies/spam.mkv`, you will get
 `~/Movies/Meteorite.spam.mkv`.
 
 Currently, there's a whole lot of debug information, dumped to both
-stderr and stdout. However, at the end of each file, you should get a
+stderr and stdout.
+Use piping of std-out to get rid of most verbose messages, i.e.
+    
+    meteorite-cli FILENAME [FILENAME]* >log.txt
+
+At the end of each run, you should get a
 banner like this:
 
     ************************************************************

--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
 WXCONFIG = wx-config
+CPP_CLI = $(CXX)  ## for CLI executable (no wx-stuff)
 CPP = `$(WXCONFIG) --cxx`
 CXXFLAGS= `$(WXCONFIG) --cxxflags` -O2
 LDFLAGS = `$(WXCONFIG) --libs`
@@ -25,7 +26,6 @@ RESOURCES= resources/resource.rc
 RESOURCE_OBJ=$(RESOURCES:.rc=.o)
 EXECUTABLE=meteorite
 EXECUTABLE_CLI=meteorite-cli
-EXECUTABLE_WIN=Meteorite.exe
 
 DESTDIR		=
 PREFIX		= $(DESTDIR)/usr
@@ -35,24 +35,18 @@ LOCALEDIR   = $(DATADIR)/locale
 
 all: $(SOURCES) $(EXECUTABLE) $(EXECUTABLE_CLI)
 
-cli: $(SOURCES_CLI) $(EXECUTABLE_CLI)
+cli: $(EXECUTABLE_CLI)
 
 $(EXECUTABLE): $(OBJECTS_GUI)
 	$(CPP) $(OBJECTS_GUI) $(LDFLAGS) -o $@
 
-$(EXECUTABLE_CLI): $(OBJECTS_CLI)
-	$(CPP) $(OBJECTS_CLI) $(LDFLAGS) -o $@
-
-win: $(SOURCES) $(RESOURCES) $(EXECUTABLE_WIN)
-
-$(EXECUTABLE_WIN): $(OBJECTS) $(RESOURCE_OBJ)
-	$(CPP) $(OBJECTS) $(RESOURCE_OBJ) $(LDFLAGS) -static-libstdc++ -static-libgcc -o $@
+$(EXECUTABLE_CLI): $(SOURCES_CLI)
+	$(CPP_CLI) $(SOURCES_CLI) -o $@
 
 %.o : %.rc
 	$(RC) $(RCFLAGS) $< -o $@
 
 .cpp.o:
-	$(CPP) $(CXXFLAGS) -c $< -o $@
 
 install:
 	install -D -m 755 $(EXECUTABLE) $(BINDIR)/$(EXECUTABLE)
@@ -76,7 +70,6 @@ clean:
 	rm -f locale/*/$(EXECUTABLE).mo
 	rm -f $(EXECUTABLE)
 	rm -f $(EXECUTABLE_CLI)
-	rm -f $(EXECUTABLE_WIN)
 	rm -rf $(EXECUTABLE).app
 
 distclean: clean

--- a/src/meteorite.cpp
+++ b/src/meteorite.cpp
@@ -1153,7 +1153,7 @@ subElement* Meteorite::ClusterRecover( char *bfr, unsigned rsize, unsigned MaxTr
 			cout << "Buffer not starting with _Cluster_ token" << endl;
 			return NULL;
 		}
-	return false;
+	return NULL;
 	}
 inline bool Meteorite::IsKeyFrame( char *data, unsigned size, char *four_cc ){ //Finds KeyFrames for indexing
 	uint32_t flag;
@@ -1578,7 +1578,7 @@ short Meteorite::ClusterMinimumBlockTime( vector< Block >& vb, unsigned TrackNo 
 			minimumtime = min(it->TimeCode, minimumtime );
 	return minimumtime;
 	}
-char* Meteorite::Clusterart(){
+const char* Meteorite::Clusterart(){
 	return "*********************************************************************\n"\
 			"*                            `,. ,;:`                               *\n"\
 			"*                         `;''''''++++;'':                          *\n"\

--- a/src/meteorite.h
+++ b/src/meteorite.h
@@ -226,7 +226,7 @@ inline bool IsKeyFrame( char *data, unsigned size, char *four_cc );
 		uint64_t ClusterDuration( vector< Block >& vb, unsigned DefaultFrameDuration, unsigned TrackNo );
 		uint64_t ClusterMaximumBlockTimePlusDuration( vector< Block >& vb, unsigned DefaultFrameDuration, unsigned TrackNo );
 		short ClusterMinimumBlockTime( vector< Block >& vb, unsigned TrackNo );
-		char* Clusterart();
+		const char* Clusterart();
 		void Generate_CueTimeCodes( vector< Block >& vb, subElement* Cues_ptr, uint64_t ClusterPosition, uint64_t ClusterTimeCode, unsigned DefaultFrameDuration, unsigned TrackNo=1 );
 		subElement* MakeCuePoint( uint64_t ClusterPosition, unsigned TrackNo, uint64_t CueTime );
 		vector<Block> ClusterBlocksAnalysis( subElement* el_ptr, subElement* root );

--- a/src/meteorite.h
+++ b/src/meteorite.h
@@ -31,9 +31,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <wx/thread.h>
-#include <wx/gauge.h>
-#include <wx/msgdlg.h>
 //#include <omp.h>
 
 #include <algorithm>


### PR DESCRIPTION
I was looking for a tool to fix my broken MKV (VLC would play it, but Handbrake would not convert it) -- and meteorite did the job.

To get it to build on **Windows** I removed the unnecessary wx-includes in meteorite.h -- I hope the GUI will still build, but it should because the includes are also present in other headers (not tested though -- I don't have wxWidgets installed).

I used the Windows g++ that comes with R-win (gcc 4.6.) and meteorite-cli.exe builds just fine using

> make cli

now (I fixed the inner workings of the makefile; it should run on any gnu make though -- also not tested -- no Linux around atm).

Hope this helps.

cheers
Chris
